### PR TITLE
[FEAT] Use email/password to construct Client

### DIFF
--- a/lib/src/api/http/easypost_request.dart
+++ b/lib/src/api/http/easypost_request.dart
@@ -49,7 +49,7 @@ class EasyPostRequest {
     request.headers['Accept'] = 'application/json';
     request.headers['Content-Type'] = 'application/json';
     request.headers['Authorization'] = 'Bearer ${config.apiKey}';
-    // request.headers['User-Agent'] = config.userAgent;
+    request.headers['User-Agent'] = config.userAgent;
 
     // Add body to a POST/PUT/PATCH request
     if (parameters != null &&

--- a/lib/src/api/services/extras_service.dart
+++ b/lib/src/api/services/extras_service.dart
@@ -4,11 +4,14 @@ import 'package:easypost/src/api/client.dart';
 import 'package:easypost/src/api/client_configuration.dart';
 import 'package:easypost/src/api/http/api_version.dart';
 import 'package:easypost/src/api/http/http_method.dart';
+import 'package:easypost/src/api/http/streamed_response.dart';
 import 'package:easypost/src/api/parameters/v2/billing/add_credit_card.dart';
 import 'package:easypost/src/base/service.dart';
 import 'package:easypost/src/enums/payment_method_priority.dart';
+import 'package:easypost/src/exceptions/api/api_exception.dart';
 import 'package:easypost/src/exceptions/json/json_deserialization_exception.dart';
 import 'package:easypost/src/exceptions/resource_not_found_exception.dart';
+import 'package:easypost/src/models/api_key.dart';
 import 'package:http/http.dart' as http;
 
 /// The [ExtrasService] handles extraneous EasyPost API functionality.
@@ -131,5 +134,121 @@ class ExtrasService extends Service {
   Client createClientWithReferralCustomerApiKey(String referralCustomerApiKey) {
     return Client(ClientConfiguration("none", referralCustomerApiKey,
         apiVersion: client.config.apiVersion, baseUrl: client.config.baseUrl));
+  }
+
+  static Future<http.Response> _rawEasyPostRequest(
+      HttpMethod method, String url,
+      {Map<String, dynamic>? parameters,
+      Map<String, String>? additionalHeaders}) async {
+    final uri = Uri.parse(url);
+    final request = http.Request(method.value, uri);
+
+    final defaultHeaders = {
+      "authority": "www.easypost.com",
+      "accept": "application/json",
+      "content-type": "application/json",
+      "origin": "https://www.easypost.com",
+      "user-agent": ClientConfiguration.getUserAgent(ApiVersion.v2),
+    };
+    if (additionalHeaders != null) {
+      defaultHeaders.addAll(additionalHeaders);
+    }
+
+    request.headers.addAll(defaultHeaders);
+
+    // Add body to a POST/PUT/PATCH request
+    if (parameters != null &&
+        (method == HttpMethod.post ||
+            method == HttpMethod.put ||
+            method == HttpMethod.patch)) {
+      request.body = jsonEncode(parameters);
+    }
+
+    final streamedResponse = await http.Client().send(request);
+
+    if (streamedResponse.isError) {
+      // request returned an error, throw the appropriate exception
+      throw await ApiException.fromStreamedResponse(streamedResponse);
+    }
+
+    return await http.Response.fromStream(streamedResponse);
+  }
+
+  static Future<String> logInWithEmailAndPasswordReturnAuthCookie(
+      String email, String password) async {
+    const String uri = "https://www.easypost.com/web_api/v1/sessions";
+    final method = HttpMethod.post;
+
+    final headers = {
+      "referer": "https://www.easypost.com/login",
+    };
+
+    const String gCaptchaResponse =
+        "03AFcWeA7dJsElDmsUtYYgPZxLZvFTOmVd4O-G0S8ApVvFw61NF6KcUlZoOjteblszCbjp3YEoCv6WC08xKKk6riWY5sQbAt4N1nvlpQw2OpNFMrfe4dLxrZXI3wbyLM4eNmCvP69anny4hqSolrWM6zBZrb2JdFct76fZAaXhu6zGZE4kFBBCIpgJjSMdSTpRGp9milHTisy_Z7nhSe5Un8VpibuvPVYmxTHpQQHTsOb9DEArUGI8WuiW21j0E4NqlMaVuH1Z0tJP8_i8D6WzmNpY3fYp-fEqDMVhxgATysAe4DQvxUw6elYV6ukeo8NHb8mw6oN4Vay1MgxrDRNUpIktCkkmtEngKy-SNEMtuP_k4H2jKbsAhbKyRuyA4yQycEPMmOlkc8KHiNtHPyr0RXEqAArsO0yhseWYXwpRyhVmHhbBHvVJDSWr9ot2PXBwKvsj8O-OqhTP0h6ImWp3Vf8c8gqC4UiScYNn0pnjdBggmXlIkEC0lE7NzGTKbXJpYLNqxZ4uUiZN-zTCL_CEiQs1GlaoAY2-huwF3hnw-o-l5Ilq_43etiZ7QZnFmTNwVVzClX4PcgFtHIbxMjT7nLe_8v_27cScXqVGUCw6sS6mwCjY2unEySDdomRbbTl_bnltmPyijpDYN18hFvdWI1EH967IYuu95w";
+
+    Map<String, dynamic> bodyData = {
+      "session": {
+        "email": email,
+        "password": password,
+        "g-recaptcha-response": gCaptchaResponse,
+      }
+    };
+
+    final response = await _rawEasyPostRequest(method, uri,
+        parameters: bodyData, additionalHeaders: headers);
+
+    String cookies = response.headers['set-cookie']!;
+
+    const String authCookieName = "easy_post_web_session=";
+
+    List<String> cookieList = cookies.split(";");
+    return cookieList.firstWhere((element) => element.contains(authCookieName));
+  }
+
+  /// Use the given authentication cookie to collect the user's API keys from easypost.com.
+  /// Returns an [ApiKeyPair] containing the user's test API key and production API key.
+  static Future<ApiKeyPair> getApiKeysUsingCookie(String cookie) async {
+    const String url =
+        "https://www.easypost.com/api/v2/api_keys?exclude_children=true";
+    final method = HttpMethod.get;
+    final headers = {
+      "cookie": cookie,
+    };
+
+    final response =
+        await _rawEasyPostRequest(method, url, additionalHeaders: headers);
+    var jsonData = jsonDecode(response.body);
+
+    return ApiKeyPair.fromWebAuthResponse(jsonData);
+  }
+}
+
+class ApiKeyPair {
+  final ApiKey? testApiKey;
+  final ApiKey? productionApiKey;
+
+  String? get testKey => testApiKey?.key;
+
+  String? get productionKey => productionApiKey?.key;
+
+  static ApiKey? _extractApiKeyFromApiKeysList(
+      List<ApiKey> apiKeys, String mode) {
+    return apiKeys.firstWhere((key) => key.mode == mode);
+  }
+
+  ApiKeyPair(this.testApiKey, this.productionApiKey);
+
+  static ApiKeyPair fromWebAuthResponse(Map<String, dynamic> json) {
+    var keysData = json['keys'];
+    List<ApiKey> keys = List<ApiKey>.empty(growable: true);
+    for (var keyData in keysData) {
+      var key = ApiKey.fromJson(keyData);
+      keys.add(key);
+    }
+
+    var testApiKey = _extractApiKeyFromApiKeysList(keys, "test");
+    var productionApiKey = _extractApiKeyFromApiKeysList(keys, "production");
+
+    return ApiKeyPair(testApiKey, productionApiKey);
   }
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1,0 +1,28 @@
+import 'package:easypost/easypost.dart';
+import 'package:test/test.dart';
+import 'package:reflectable/reflectable.dart';
+import 'package:easypost/src/constants.dart';
+
+import 'fixtures.dart';
+import 'test_utils.dart';
+// import 'client_test.reflectable.dart';
+
+void main() {
+  group('Client', () {
+    setUp(() {
+      // Additional setup goes here.
+      // initializeReflectable();
+    });
+
+    test('login with email and password', () async {
+      TestVCR vcr = TestVCR(testCassettesFolder: "client");
+
+      String email = loginEmail;
+      String password = loginPassword;
+
+      ClientConfiguration configuration = await ClientConfiguration.fromEmailAndPassword(email, password);
+
+      expect(configuration, isNotNull);
+    });
+  });
+}

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -33,6 +33,10 @@ String getApiKey(ApiKeyEnum keyType) {
           ._apiKeyFailedToPull; // if can't pull from environment, will use a fake key. Won't matter on replay.
 }
 
+String get loginEmail => Platform.environment["EASYPOST_LOGIN_EMAIL"] ?? "";
+
+String get loginPassword => Platform.environment["EASYPOST_LOGIN_PASSWORD"] ?? "";
+
 class TestUtils {
   static final String _apiKeyFailedToPull = "couldnotpullapikey";
 


### PR DESCRIPTION
- Add ability to use email/password combo to initialize ClientConfiguration rather than test/prod API keys
- Re-enable missing User Agent for all API calls